### PR TITLE
SQLite converter library fixes for ProteoSAFe result views

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,5 @@ target/
 /venv
 /.idea
 /.vscode
+/.project
+/.pydevproject

--- a/csv_to_sqlite.py
+++ b/csv_to_sqlite.py
@@ -46,7 +46,8 @@ class CsvFileInfo:
         self.lb, self.rb = ("[", "]") if options.bracket_style == "all" else ("", "")
 
     def get_table_name(self):
-        return os.path.splitext(os.path.basename(self.path))[0]
+        #return os.path.splitext(os.path.basename(self.path))[0]
+        return "Result"
 
     def get_minimal_type(self, value):
         try:


### PR DESCRIPTION
Set table name to static "Result", rather than using the input TSV filename, since SQLite is finicky about the characters that can be used in table names and thus any special characters in the input TSV filename will break the conversion.